### PR TITLE
feat: add answerCustomChallenge action

### DIFF
--- a/packages/cognito-module/src/actions.js
+++ b/packages/cognito-module/src/actions.js
@@ -8,7 +8,7 @@ export default {
         Auth.currentUserPoolUser()
           .then(user => {
             commit('setUser', user)
-            commit('setSession', session)
+
             resolve(session)
           }).catch(reject)
       }).catch(reject)
@@ -17,9 +17,14 @@ export default {
     new Promise((resolve, reject) => {
       Auth.signIn(credentials.username, credentials.password).then((user) => {
         commit('setUser', user)
-        commit('setSession', user.signInUserSession)
 
-        if (localStorage) localStorage.setItem('USER', JSON.stringify(user))
+        resolve(user)
+      }).catch(reject)
+    }),
+  answerCustomChallenge: ({ commit }, credentials) =>
+    new Promise((resolve, reject) => {
+      Auth.sendCustomChallengeAnswer(credentials.user, credentials.answer).then((user) => {
+        commit('setUser', user)
 
         resolve(user)
       }).catch(reject)
@@ -33,9 +38,6 @@ export default {
         attributes: credentials.attributes
       }).then(user => {
         commit('setUser', user)
-        commit('setSession', user.signInUserSession)
-
-        if (localStorage) localStorage.setItem('USER', user)
 
         resolve(user)
       }).catch(reject)
@@ -77,7 +79,6 @@ export default {
       Auth.signOut()
         .then(result => {
           commit('setUser', {})
-          commit('setSession', {})
 
           resolve(result)
         })

--- a/packages/cognito-module/src/mutations.js
+++ b/packages/cognito-module/src/mutations.js
@@ -1,7 +1,8 @@
 // Utils
-import { set } from '../utils/vuex'
 
 export default {
-  setUser: set('user'),
-  setSession: set('session')
+  setUser: (state, user) => {
+    state.user = JSON.parse(JSON.stringify(user))
+    state.session = state.user.signInUserSession
+  }
 }


### PR DESCRIPTION
It is need for custom auth flow e.g. passwordless https://aws-amplify.github.io/docs/js/authentication#using-a-custom-challenge
Also converts user to POJO object, because otherwise with simple assignment there will be two problems

amplify lib can mutate user object itself and it will lead to vuex error that state mutated from outside of actions. It could be avoided using Object.assing but there 2
nuxt will warn if vuex object not fully serializable e.g. non POJO nuxt/nuxt.js#4046
