### PR TITLE
fix/cognito-userSub-getter

### DIFF
--- a/packages/cognito-module/src/getters.js
+++ b/packages/cognito-module/src/getters.js
@@ -14,10 +14,15 @@ module.exports = {
     Object.keys(store.session).length !== 0
     ? store.session
     : false,
-  userSub: (store = {}) => store.user &&
-    store.user.attributes
-    ? store.user.attributes.sub
-    : false,
+  userSub: (store = {}) => {
+    if (store.user && store.user.attributes) {
+      return store.user.attributes.sub
+    } else if (store.user && store.user.userSub) {
+      return store.user.userSub
+    } else {
+      return false
+    }
+  },
   username: (store = {}) => store.user &&
     store.user.user
     ? store.user.user.username


### PR DESCRIPTION
# Quick description.

- When the user was either in a register process using this module, or logging in, the userSub would be available in different attributes of the user's object, hence sometimes it would not be correctly fetched according to the situation. The getter enhancement now correctly returns the user's UUID if they are either registering a Cognito user into the Pool or they are logging in.