### PR TITLE
add fetchCurrentAuthenticatedUser action to cognito module

### DIFF
--- a/packages/cognito-module/docs/api/actions.md
+++ b/packages/cognito-module/docs/api/actions.md
@@ -1,5 +1,11 @@
 # Actions
 
+### `fetchCurrentAuthenticatedUser()`
+Fetches the current authenticated user in browser store and sets user and session in store.
+```js
+this.$store.dispatch('cognito/fetchCurrentAuthenticatedUser)
+```
+
 ### `fetchSession()`
 Fetches the latest information on the current user and session state.
 

--- a/packages/cognito-module/src/actions.js
+++ b/packages/cognito-module/src/actions.js
@@ -2,7 +2,7 @@ import Auth from '@aws-amplify/auth'
 import Amplify from '@aws-amplify/core'
 
 export default {
-  fetchCurrentAuthenticatedCuser: ({ commit }) => {
+  fetchCurrentAuthenticatedUser: ({ commit }) => {
     return new Promise((resolve, reject) => {
       Auth.currentAuthenticatedUser()
         .then((user) => {

--- a/packages/cognito-module/src/actions.js
+++ b/packages/cognito-module/src/actions.js
@@ -2,6 +2,16 @@ import Auth from '@aws-amplify/auth'
 import Amplify from '@aws-amplify/core'
 
 export default {
+  fetchCurrentAuthenticatedCuser: ({ commit }) => {
+    return new Promise((resolve, reject) => {
+      Auth.currentAuthenticatedUser()
+        .then((user) => {
+          commit('setUser', user)
+          resolve(user)
+        })
+        .catch(reject)
+    })
+  },
   fetchSession: ({ commit }) =>
     new Promise((resolve, reject) => {
       Auth.currentSession().then(session => {


### PR DESCRIPTION
- allows us to check for current auth'd user cached in browser

